### PR TITLE
Display number of likes for each item and added all items counter on the homepage

### DIFF
--- a/src/modules/api/api.js
+++ b/src/modules/api/api.js
@@ -4,9 +4,33 @@ import displayMovies from '../dom.js';
 const key = process.env.MOVIEDB_API_SECRET;
 const baseUrl = process.env.MOVIEDB_API_LINK;
 const url = `${baseUrl}/popular?api_key=${key}&language=en-US&page=1`;
+const urlInvolvement = process.env.INVOLVEMENT_API_LINK;
+const idInvolvement = process.env.INVOLVEMENT_ID;
+
+const postData = async (id) => {
+  const response = await axios.post(
+    `${urlInvolvement}/apps/${idInvolvement}/likes/`,
+    {
+      item_id: `${id}`,
+    },
+  );
+  return (response.data);
+};
 
 const getData = async () => {
   const response = await axios.get(`${url}`);
-  displayMovies(response.data.results);
+  await displayMovies(response.data.results);
+  const items = document.querySelectorAll('.like');
+  items.forEach((item) => {
+    item.addEventListener('click', async (event) => {
+      const res = await postData(item.id);
+      if (res === 'Created') {
+        const number = event.target.parentNode.parentNode.childNodes[5].childNodes[0].innerHTML;
+        // eslint-disable-next-line max-len
+        event.target.parentNode.parentNode.childNodes[5].childNodes[0].innerHTML = (Number(number) + 1);
+        event.target.outerHTML = `<i id="${item.id}" class="fa fa-heart"></i>`;
+      }
+    });
+  });
 };
 export default getData;

--- a/src/modules/api/api.js
+++ b/src/modules/api/api.js
@@ -34,7 +34,7 @@ const likesCounter = () => {
       }
     });
   });
-}
+};
 
 const getData = async () => {
   const response = await axios.get(`${url}`);

--- a/src/modules/api/api.js
+++ b/src/modules/api/api.js
@@ -8,18 +8,20 @@ const urlInvolvement = process.env.INVOLVEMENT_API_LINK;
 const idInvolvement = process.env.INVOLVEMENT_ID;
 
 const postData = async (id) => {
-  const response = await axios.post(
-    `${urlInvolvement}/apps/${idInvolvement}/likes/`,
-    {
-      item_id: `${id}`,
-    },
-  );
-  return (response.data);
+  try {
+    const response = await axios.post(
+      `${urlInvolvement}/apps/${idInvolvement}/likes/`,
+      {
+        item_id: `${id}`,
+      },
+    );
+    return (response.data);
+  } catch (error) {
+    return error;
+  }
 };
 
-const getData = async () => {
-  const response = await axios.get(`${url}`);
-  await displayMovies(response.data.results);
+const likesCounter = () => {
   const items = document.querySelectorAll('.like');
   items.forEach((item) => {
     item.addEventListener('click', async (event) => {
@@ -32,5 +34,11 @@ const getData = async () => {
       }
     });
   });
+}
+
+const getData = async () => {
+  const response = await axios.get(`${url}`);
+  await displayMovies(response.data.results);
+  likesCounter();
 };
 export default getData;

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -19,7 +19,7 @@ const displayMovies = async (data) => {
       (info) => info.item_id === movie.id.toString(),
     );
     // show likes
-    const showLikes = likes.length === 0 ? '' : `<span class="like-count">${likes[0].likes}</span> likes`;
+    const showLikes = likes.length === 0 ? '<span class="like-count">0</span> likes' : `<span class="like-count">${likes[0].likes}</span> likes`;
     section.innerHTML += `
       <div class="movie-card">
           <img class="img-card" src="https://image.tmdb.org/t/p/original${movie.poster_path}" alt="">

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -3,10 +3,14 @@ import axios from 'axios';
 const urlInvolvement = process.env.INVOLVEMENT_API_LINK;
 const idInvolvement = process.env.INVOLVEMENT_ID;
 const receiveData = async () => {
-  const response = await axios.get(
-    `${urlInvolvement}/apps/${idInvolvement}/likes/`,
-  );
-  return response.data;
+  try {
+    const response = await axios.get(
+      `${urlInvolvement}/apps/${idInvolvement}/likes/`,
+    );
+    return response.data;
+  } catch (error) {
+    return error;
+  }
 };
 const displayMovies = async (data) => {
   const main = document.querySelector('.main');

--- a/src/modules/dom.js
+++ b/src/modules/dom.js
@@ -1,13 +1,30 @@
-const displayMovies = (data) => {
+import axios from 'axios';
+
+const urlInvolvement = process.env.INVOLVEMENT_API_LINK;
+const idInvolvement = process.env.INVOLVEMENT_ID;
+const receiveData = async () => {
+  const response = await axios.get(
+    `${urlInvolvement}/apps/${idInvolvement}/likes/`,
+  );
+  return response.data;
+};
+const displayMovies = async (data) => {
   const main = document.querySelector('.main');
   main.innerHTML = '';
   const section = document.createElement('section');
   section.classList.add('movie-container');
+  const dataInfo = await receiveData();
   data.forEach((movie) => {
+    const likes = dataInfo.filter(
+      (info) => info.item_id === movie.id.toString(),
+    );
+    // show likes
+    const showLikes = likes.length === 0 ? '' : `<span class="like-count">${likes[0].likes}</span> likes`;
     section.innerHTML += `
       <div class="movie-card">
           <img class="img-card" src="https://image.tmdb.org/t/p/original${movie.poster_path}" alt="">
-          <div class="title-icon"><h2>${movie.title}</h2><i class="fa fa-heart-o"></i></div>
+          <div class="title-icon"><h2>${movie.title}</h2><i id="${movie.id}" class="fa fa-heart-o like"></i></div>
+          <div class="likes">${showLikes}</div>
           <div class="btn"> <button href="/movie#${movie.id}" class="spaLink btn-1">Comments</button>       
       </div>
       `;

--- a/src/modules/main.js
+++ b/src/modules/main.js
@@ -1,5 +1,7 @@
 import imgHelper from './util.js';
+
 import getData from './api/api.js';
+
 // eslint-disable-next-line import/no-cycle
 import { links } from './router/router.js';
 

--- a/src/style.css
+++ b/src/style.css
@@ -76,7 +76,7 @@ main {
   height: 50px;
 }
 
-.fa-heart-o {
+.fa {
   color: #35caf1;
   font-weight: bold;
   display: flex;
@@ -105,6 +105,10 @@ h2:hover {
   width: 100%;
   height: 350px;
   object-fit: cover;
+}
+
+.likes {
+  text-align: right;
 }
 
 .btn {
@@ -284,8 +288,12 @@ footer {
       height: auto;
     }
 
-    .fa-heart-o {
+    .fa {
       display: block;
+      text-align: center;
+    }
+    
+    .likes {
       text-align: center;
     }
   }

--- a/src/style.css
+++ b/src/style.css
@@ -292,7 +292,7 @@ footer {
       display: block;
       text-align: center;
     }
-    
+
     .likes {
       text-align: center;
     }


### PR DESCRIPTION
I did the following in this milestone;
- Made sure that the correct number is displayed on the Homepage
- When the user clicks on the Like button of an item (on Homepage), the interaction is recorded in the Involvement API and the screen is updated.
- When the page loads, the webapp the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API.